### PR TITLE
More build fixes

### DIFF
--- a/src/unBand.CargoClientExtender/BluetoothDeviceTransport.cs
+++ b/src/unBand.CargoClientExtender/BluetoothDeviceTransport.cs
@@ -48,7 +48,7 @@ namespace unBand.CargoClientExtender
 
             if (deviceService == null)
             {
-                throw new Exception("Failed to create RfcommDeviceService with id: " + _deviceInfo.Id.ToString());
+                throw new Exception("Failed to create RfcommDeviceService with name: " + _deviceInfo.Name.ToString());
             }
 
             var streamSocket = new StreamSocket();

--- a/src/unBand.CargoClientExtender/BluetoothDeviceTransport.cs
+++ b/src/unBand.CargoClientExtender/BluetoothDeviceTransport.cs
@@ -21,7 +21,7 @@ namespace unBand.CargoClientExtender
         private bool _disposed;
         
         public CargoStreamReader CargoReader { get; private set; }
-        public Stream CargoStream { get; private set; }
+        public ICargoStream CargoStream { get; private set; }
         public CargoStreamWriter CargoWriter { get; private set; }
         public bool IsConnected { get; private set; }
         public int MaxDataPayloadSize { get; private set; }

--- a/src/unBand.CargoClientExtender/BluetoothStreamWrapper.cs
+++ b/src/unBand.CargoClientExtender/BluetoothStreamWrapper.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.Networking.Sockets;
+using Microsoft.Band;
 
 namespace unBand.CargoClientExtender
 {
@@ -13,7 +14,7 @@ namespace unBand.CargoClientExtender
     /// Small StreamSocket wrapper (really around Stream, but implemented on top of a StreamSocket)
     /// that implemented Read/Write Timeouts
     /// </summary>
-    internal class BluetoothStreamWrapper : Stream
+    internal class BluetoothStreamWrapper : Stream, ICargoStream
     {
         const int DEFAULT_WRITE_TIMEOUT = 1000;
         const int DEFAULT_READ_TIMEOUT = 1000;
@@ -32,6 +33,12 @@ namespace unBand.CargoClientExtender
 
         public override int ReadTimeout { get; set; }
         public override int WriteTimeout { get; set; }
+
+        public CancellationToken Cancel
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
 
         public override long Length { get { throw new NotImplementedException(); } }
 

--- a/src/unBand.CargoClientExtender/unBand.CargoClientExtender.csproj
+++ b/src/unBand.CargoClientExtender/unBand.CargoClientExtender.csproj
@@ -35,20 +35,21 @@
     <TargetPlatformVersion>8.1</TargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Band.Admin.Desktop.unband">
-      <HintPath>..\Microsoft.Band.Admin.Desktop.unband.dll</HintPath>
+    <Reference Include="Microsoft.Band">
+      <HintPath>..\Microsoft.Band.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Band.Admin.unband">
-      <HintPath>..\Microsoft.Band.Admin.unband.dll</HintPath>
+    <Reference Include="Microsoft.Band.Admin">
+      <HintPath>..\Microsoft.Band.Admin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Band.Desktop.unband">
-      <HintPath>..\Microsoft.Band.Desktop.unband.dll</HintPath>
+    <Reference Include="Microsoft.Band.Admin.Desktop">
+      <HintPath>..\Microsoft.Band.Admin.Desktop.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Band.unband">
-      <HintPath>..\Microsoft.Band.unband.dll</HintPath>
+    <Reference Include="Microsoft.Band.Desktop">
+      <HintPath>..\Microsoft.Band.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.InteropServices.WindowsRuntime" />
     <Reference Include="System.Runtime.WindowsRuntime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">

--- a/src/unBand.CargoClientExtender/unBand.CargoClientExtender.csproj
+++ b/src/unBand.CargoClientExtender/unBand.CargoClientExtender.csproj
@@ -56,6 +56,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\Windows\Microsoft.NET\Framework64\v4.0.30319\System.Runtime.WindowsRuntime.dll</HintPath>
     </Reference>
+    <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/unBand.Cloud.Tests/BandMapPointCollectionTests.cs
+++ b/src/unBand.Cloud.Tests/BandMapPointCollectionTests.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ploeh.AutoFixture;
+using unBand.Cloud.Events;
+
+namespace unBand.Cloud.Tests
+{
+    [TestClass]
+    public class BandMapPointCollectionTests
+    {
+        private IFixture _fixture;
+        private BandMapPointCollection _subjectUnderTest;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            _fixture = new Fixture();
+        }
+
+        [TestMethod]
+        public void FiltersInvalidBeginMiddleEndMapPointFromCollection()
+        {
+            DoTest(3, 0);
+            DoTest(3, 1);
+            DoTest(3, 2);
+        }
+
+        private void DoTest(int collectionSize, int indexOfInvalidMapPoint)
+        {
+            _subjectUnderTest = new BandMapPointCollection();
+            var mapPoints = CreateTestData(collectionSize);
+            MakeInvalid(mapPoints[indexOfInvalidMapPoint]);
+            PopulateCollection(mapPoints);
+
+            Assert.AreEqual(_subjectUnderTest.Count(), collectionSize - 1);
+            Assert.IsFalse(_subjectUnderTest.Contains(mapPoints[indexOfInvalidMapPoint]));
+        }
+
+        private List<BandMapPoint> CreateTestData(int repeatCount)
+        {
+            _fixture.RepeatCount = repeatCount;
+            return _fixture.CreateMany<BandMapPoint>().ToList();
+        }
+
+        private void PopulateCollection(List<BandMapPoint> data)
+        {
+            data.ForEach(x => _subjectUnderTest.Add(x));
+        }
+
+        private void MakeInvalid(BandMapPoint subject)
+        {
+            subject.Latitude = 0.0;
+            subject.Longitude = 0.0;
+            subject.Altitude = 0.0;
+        }
+    }
+}

--- a/src/unBand.Cloud.Tests/Properties/AssemblyInfo.cs
+++ b/src/unBand.Cloud.Tests/Properties/AssemblyInfo.cs
@@ -5,12 +5,12 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("unBand.Cloud")]
+[assembly: AssemblyTitle("unBand.Cloud.Tests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("unBand.Cloud")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyProduct("unBand.Cloud.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("5ab6fca4-a00a-495f-8941-41c4a4cd7424")]
+[assembly: Guid("b184addb-a2f1-422f-912f-05e57f3d83be")]
 
 // Version information for an assembly consists of the following four values:
 //
@@ -34,4 +34,3 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: InternalsVisibleTo("unBand.Cloud.Tests")]

--- a/src/unBand.Cloud.Tests/packages.config
+++ b/src/unBand.Cloud.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AutoFixture" version="3.30.3" targetFramework="net45" />
+</packages>

--- a/src/unBand.Cloud.Tests/unBand.Cloud.Tests.csproj
+++ b/src/unBand.Cloud.Tests/unBand.Cloud.Tests.csproj
@@ -1,0 +1,96 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{32DEEBC3-DB59-4D5C-AE4B-FB7CE2E96B41}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>unBand.Cloud.Tests</RootNamespace>
+    <AssemblyName>unBand.Cloud.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Ploeh.AutoFixture, Version=3.30.3.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.3.30.3\lib\net40\Ploeh.AutoFixture.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="BandMapPointCollectionTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\unBand.Cloud\unBand.Cloud.csproj">
+      <Project>{c65bd296-f5e1-400e-886e-bc3def6476ef}</Project>
+      <Name>unBand.Cloud</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/unBand.Cloud/Events/BandMapPointCollection.cs
+++ b/src/unBand.Cloud/Events/BandMapPointCollection.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace unBand.Cloud.Events
+{
+    internal class BandMapPointCollection : IEnumerable<BandMapPoint>
+    {
+        private readonly List<BandMapPoint> _mapPoints = new List<BandMapPoint>();
+
+        internal void Add(BandMapPoint mapPoint)
+        {
+            _mapPoints.Add(mapPoint);
+        }
+
+        public IEnumerator<BandMapPoint> GetEnumerator()
+        {
+            return _mapPoints.FilterInvalidCoordinates().GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+
+    internal static class BandMapPointFilterExtensions
+    {
+        public static IEnumerable<BandMapPoint> FilterInvalidCoordinates(this IEnumerable<BandMapPoint> self)
+        {
+            return self.Where(IsValid);
+        }
+
+        private static bool IsValid(BandMapPoint point)
+        {
+            return !((int) point.Latitude == 0 &&
+                     (int) point.Longitude == 0 &&
+                     (int) point.Altitude == 0);
+        }
+    }
+}

--- a/src/unBand.Cloud/Events/BikeEvent.cs
+++ b/src/unBand.Cloud/Events/BikeEvent.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using unBand.Cloud.Events;
 using unBand.Cloud.Exporters.EventExporters;
 
 namespace unBand.Cloud
@@ -47,7 +48,7 @@ namespace unBand.Cloud
     [TypeConverter(typeof(BikeEventConverter))]
     public class BikeEvent : BandExerciseEventBase, IBandEventWithMapPoints
     {
-
+        private readonly BandMapPointCollection _mapPoints = new BandMapPointCollection();
         private static List<IEventExporter> _exporters;
 
         public override List<IEventExporter> Exporters
@@ -69,7 +70,7 @@ namespace unBand.Cloud
             get { return new BandEventExpandType[] { BandEventExpandType.Info, BandEventExpandType.Sequences, BandEventExpandType.MapPoints }; }
         }
 
-        public List<BandMapPoint> MapPoints { get; private set; }
+        public IEnumerable<BandMapPoint> MapPoints { get{return _mapPoints;} }
 
         /// <summary>
         /// Calculated property which indicates whether or not any actual GPS points were
@@ -86,9 +87,7 @@ namespace unBand.Cloud
         public int Pace { get; set; }
 
         public BikeEvent(JObject json) : base(json)
-        {
-            MapPoints = new List<BandMapPoint>();
-            
+        {           
             dynamic eventSummary = (dynamic)json;
 
             TotalDistance     = eventSummary.TotalDistance;
@@ -146,7 +145,7 @@ namespace unBand.Cloud
                     HasGPSPoints = true;
                 }
 
-                MapPoints.Add(runMapPoint);
+                _mapPoints.Add(runMapPoint);
             }
         }
     }

--- a/src/unBand.Cloud/Events/IBandEventWithMapPoints.cs
+++ b/src/unBand.Cloud/Events/IBandEventWithMapPoints.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
+using unBand.Cloud.Events;
 
 namespace unBand.Cloud
 {
     public interface IBandEventWithMapPoints
     {
         bool HasGPSPoints { get; set; }
-
-        List<BandMapPoint> MapPoints { get; }
+        IEnumerable<BandMapPoint> MapPoints { get; }
     }
 }

--- a/src/unBand.Cloud/Events/RunEvent.cs
+++ b/src/unBand.Cloud/Events/RunEvent.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using unBand.Cloud.Events;
 using unBand.Cloud.Exporters.EventExporters;
 
 namespace unBand.Cloud
@@ -51,7 +52,7 @@ namespace unBand.Cloud
     [TypeConverter(typeof(RunEventConverter))]
     public class RunEvent : BandExerciseEventBase, IBandEventWithMapPoints
     {
-
+        private readonly BandMapPointCollection _mapPoints = new BandMapPointCollection();
         private static List<IEventExporter> _exporters;
 
         public override List<IEventExporter> Exporters
@@ -73,7 +74,7 @@ namespace unBand.Cloud
             get { return new BandEventExpandType[] { BandEventExpandType.Info, BandEventExpandType.Sequences, BandEventExpandType.MapPoints }; }
         }
 
-        public List<BandMapPoint> MapPoints { get; private set; }
+        public IEnumerable<BandMapPoint> MapPoints { get { return _mapPoints; } }
 
         /// <summary>
         /// Calculated property which indicates whether or not any actual GPS points were
@@ -90,9 +91,7 @@ namespace unBand.Cloud
         public int Pace { get; set; }
 
         public RunEvent(JObject json) : base(json)
-        {
-            MapPoints = new List<BandMapPoint>();
-            
+        {           
             dynamic eventSummary = (dynamic)json;
 
             TotalDistance     = eventSummary.TotalDistance;
@@ -151,7 +150,7 @@ namespace unBand.Cloud
                     HasGPSPoints = true;
                 }
 
-                MapPoints.Add(runMapPoint);
+                _mapPoints.Add(runMapPoint);
             }
         }
     }

--- a/src/unBand.Cloud/unBand.Cloud.csproj
+++ b/src/unBand.Cloud/unBand.Cloud.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Events\BandExerciseEventBase.cs" />
     <Compile Include="Events\BandEventBase.cs" />
     <Compile Include="Events\BandMapPoint.cs" />
+    <Compile Include="Events\BandMapPointCollection.cs" />
     <Compile Include="Events\ExerciseEventSequenceItem.cs" />
     <Compile Include="Events\BikeEvent.cs" />
     <Compile Include="Events\IBandEventWithMapPoints.cs" />

--- a/src/unBand.sln
+++ b/src/unBand.sln
@@ -1,7 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "unBand", "unBand\unBand.csproj", "{37740797-A1D3-4452-AB73-DC24EAD9CFBF}"
 EndProject
@@ -14,6 +13,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "unBand.dev.Bootstrap", "unBand.dev.Bootstrap\unBand.dev.Bootstrap.csproj", "{3E06AE5E-340A-4240-A233-EECCF718EB8A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "unBand.CargoClientEditor", "unBand.CargoClientEditor\unBand.CargoClientEditor.csproj", "{3BD070E3-1D3C-437D-B079-81879654F228}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{681082A6-0D5C-47BA-BA85-D4B91E0D1A52}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "unBand.Cloud.Tests", "unBand.Cloud.Tests\unBand.Cloud.Tests.csproj", "{32DEEBC3-DB59-4D5C-AE4B-FB7CE2E96B41}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,8 +48,15 @@ Global
 		{3BD070E3-1D3C-437D-B079-81879654F228}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3BD070E3-1D3C-437D-B079-81879654F228}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3BD070E3-1D3C-437D-B079-81879654F228}.Release|Any CPU.Build.0 = Release|Any CPU
+		{32DEEBC3-DB59-4D5C-AE4B-FB7CE2E96B41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32DEEBC3-DB59-4D5C-AE4B-FB7CE2E96B41}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32DEEBC3-DB59-4D5C-AE4B-FB7CE2E96B41}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{32DEEBC3-DB59-4D5C-AE4B-FB7CE2E96B41}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{32DEEBC3-DB59-4D5C-AE4B-FB7CE2E96B41} = {681082A6-0D5C-47BA-BA85-D4B91E0D1A52}
 	EndGlobalSection
 EndGlobal

--- a/src/unBand/BandHelpers/BandProperties.cs
+++ b/src/unBand/BandHelpers/BandProperties.cs
@@ -94,7 +94,7 @@ namespace unBand.BandHelpers
             FirmwareVersions = await _client.GetFirmwareVersionsAsync();
             EphemerisCoverageDates = await _client.GetGpsEphemerisCoverageDatesFromDeviceAsync();
             LogVersion = await _client.GetLogVersionAsync();
-            MaxStrappCount = await _client.GetMaxStrappCountAsync();
+            MaxStrappCount = await _client.GetMaxTileCountAsync();
             
             PendingDeviceDataBytes = await _client.GetPendingDeviceDataBytesAsync();
             // var j = await _client.GetPendingLocalDataBytesAsync(); NullException

--- a/src/unBand/BandHelpers/BandStrapp.cs
+++ b/src/unBand/BandHelpers/BandStrapp.cs
@@ -19,7 +19,7 @@ namespace unBand.BandHelpers
         // to others / edit it), so let's detect that
         private static readonly Guid STARBUCKS_GUID = new Guid("{64a29f65-70bb-4f32-99a2-0f250a05d427}");
 
-        public CargoStrapp Strapp { get; private set; }
+        public AdminBandTile Strapp { get; private set; }
 
         public WriteableBitmap TileImage { get; private set; }
 
@@ -29,16 +29,16 @@ namespace unBand.BandHelpers
         {
             get
             {
-                return _tiles.DefaultStrapps.Any(i => i.StrappID == Strapp.StrappID);
+                return _tiles.DefaultStrapps.Any(i => i.TileId == Strapp.TileId);
             }
         }
 
         public bool IsStarbucks
         {
-            get { return Strapp.StrappID == STARBUCKS_GUID; }
+            get { return Strapp.TileId == STARBUCKS_GUID; }
         }
 
-        public BandStrapp(BandTiles tiles, CargoStrapp strapp)
+        public BandStrapp(BandTiles tiles, AdminBandTile strapp)
         {
             Strapp = strapp;
             _tiles = tiles;
@@ -65,7 +65,7 @@ namespace unBand.BandHelpers
 
             var images = new List<BandIcon>() { bmp.ToBandIcon(), bmp.ToBandIcon() };
 
-            Strapp.SetImageList(Strapp.StrappID, images, 0);
+            Strapp.SetImageList(Strapp.TileId, images, 0);
 
             _tiles.UpdateStrapp(Strapp);
 

--- a/src/unBand/BandHelpers/BandTheme.cs
+++ b/src/unBand/BandHelpers/BandTheme.cs
@@ -39,7 +39,7 @@ namespace unBand.BandHelpers
         private bool _inited;
 
         private WriteableBitmap _background;
-        private Microsoft.Band.Personalization.BandTheme _themeColor;
+        private Microsoft.Band.BandTheme _themeColor;
 
         private SolidColorBrush _baseColor;
         private SolidColorBrush _highlightColor;
@@ -203,6 +203,7 @@ namespace unBand.BandHelpers
 
             if (meTileImage != null)
                 _background = meTileImage.ToWriteableBitmap();
+
 
             _themeColor = await _client.PersonalizationManager.GetThemeAsync();
 

--- a/src/unBand/BandHelpers/BandTiles.cs
+++ b/src/unBand/BandHelpers/BandTiles.cs
@@ -15,7 +15,7 @@ namespace unBand.BandHelpers
 
         public ObservableCollection<BandStrapp> Strip { get; private set; }
 
-        public List<CargoStrapp> DefaultStrapps { get; private set; }
+        public List<AdminBandTile> DefaultStrapps { get; private set; }
 
         public BandTiles(CargoClient client)
         {
@@ -42,7 +42,7 @@ namespace unBand.BandHelpers
             
             Strip = new ObservableCollection<BandStrapp>(bandStrip);
 
-            DefaultStrapps = (List<CargoStrapp>)(await _client.GetDefaultStrappsAsync());
+            DefaultStrapps = (List<AdminBandTile>)(await _client.GetDefaultTilesAsync());
         }
 
         public Task Save()
@@ -58,13 +58,13 @@ namespace unBand.BandHelpers
         {
             foreach (var bandStrapp in Strip)
             {
-                await _client.ClearStrappAsync(bandStrapp.Strapp.StrappID);
+                await _client.ClearTileAsync(bandStrapp.Strapp.TileId);
             }
         }
 
-        internal void UpdateStrapp(CargoStrapp strapp)
+        internal void UpdateStrapp(AdminBandTile strapp)
         {
-            _client.UpdateStrapp(strapp);
+            _client.UpdateTile(strapp);
 
             // here is where it gets a bit hairy. If we just call UpdateStrapp alone
             // it will shove the updated Tile at the end of the strip, which is undesirable


### PR DESCRIPTION
Build fixes resulting from the new MS Band dll API changes in v1.3.10423.3. Band no longer crashes on connection, themes, retrieval of tiles & activities etc all seem to work fine after changes. Would be worth someone more familiar with the UI aspects on unBand to give this double check though please.